### PR TITLE
Add SecretStr to secret attrs and some gitignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,6 @@ ipython_config.py
 # poetry
 poetry.lock
 
-
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,10 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# poetry
+poetry.lock
+
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 
@@ -106,6 +110,7 @@ celerybeat.pid
 
 # Environments
 .env
+*.env
 .venv
 env/
 venv/
@@ -140,6 +145,7 @@ cython_debug/
 report*json
 
 .vscode/
+.idea/
 
 result
 .pdm-python

--- a/ptsandbox/models/api/key.py
+++ b/ptsandbox/models/api/key.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from functools import cached_property
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 
 class SandboxKey(BaseModel):
@@ -16,16 +16,16 @@ class SandboxKey(BaseModel):
             default = 0
             ldap = 1
 
-        login: str
-        password: str
+        login: SecretStr
+        password: SecretStr
         auth_type: AuthType = AuthType.default
 
-    name: str
+    name: SecretStr
     """
     Custom key name
     """
 
-    key: str
+    key: SecretStr
     """
     The key received in the sandbox interface
     """

--- a/ptsandbox/sandbox/sandbox_api.py
+++ b/ptsandbox/sandbox/sandbox_api.py
@@ -66,7 +66,7 @@ class SandboxApi:
                     resolver=aiohttp.ThreadedResolver(),
                 )
             ),
-            headers={"X-Api-Key": key.key},
+            headers={"X-Api-Key": key.key.get_secret_value()},
         )
         self.http_client = AsyncHTTPClient(self.session, logger=logger)
 

--- a/ptsandbox/sandbox/sandbox_ui.py
+++ b/ptsandbox/sandbox/sandbox_ui.py
@@ -180,8 +180,8 @@ class SandboxUI:
         assert self.key.ui is not None
 
         data: dict[str, str | bool | SandboxKey.UI.AuthType] = {
-            "username": self.key.ui.login,
-            "password": self.key.ui.password,
+            "username": self.key.ui.login.get_secret_value(),
+            "password": self.key.ui.password.get_secret_value(),
             "authType": self.key.ui.auth_type,
             "rememberLogin": True,
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ptsandbox"
-version = "5.0.4"
+version = "5.0.5"
 description = "Async API connector for PT Sandbox instances"
 readme = "README.md"
 requires-python = "<4.0,>=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "ptsandbox"
-version = "5.0.4"
+version = "5.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
изменил тип данных для логина, пароля, ключа песка типа на SecretStr из pydantic\
и изменил последующую обработку этих строк в запросе фактических кук и токена

это нужно было, чтобы при дебаге, а также случайном выводе SandboxKey чувствительная информация не показывалась (Protected Attributes). 

и чуть докинул в gitignore, чтобы с PyCharm и poetry не закидывались временные файлы